### PR TITLE
Use action sha

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -49,7 +49,7 @@ jobs:
           sudo apt-get install git -y
 
       - name: Check out repository code
-        uses: rodrigorodriguescosta/checkout@main  # FIXME: Not using actions/checkout just because of 'https://github.com/actions/checkout/pull/388'
+        uses: rodrigorodriguescosta/checkout@1d64c0a4a695ff5edb95596c11b430050668c83f  # FIXME: Not using actions/checkout just because of 'https://github.com/actions/checkout/pull/388'
         with:
           path: /home/conan/library
 

--- a/.github/workflows/create_tag_release.yml
+++ b/.github/workflows/create_tag_release.yml
@@ -37,7 +37,7 @@ jobs:
       - release-available
     runs-on: ubuntu-latest
     steps:
-      - uses: "marvinpinto/action-automatic-releases@latest"
+      - uses: "marvinpinto/action-automatic-releases@4edd7a5aabb1bc62e6dc99b3302d587bf3134e20"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           draft: true


### PR DESCRIPTION
Security reasons: modified action (same tag) might capture credentials